### PR TITLE
 Always take input msg as query when present

### DIFF
--- a/plugins/custom/gs/__main__.py
+++ b/plugins/custom/gs/__main__.py
@@ -21,7 +21,7 @@ async def jv_gsearch(message: Message):
     await message.edit(f"**Googling** for `{query}` ...")
     flags = message.flags
     limit = int(flags.get('-l', 6))
-    if message.reply_to_message:
+    if message.reply_to_message and not query:
         query = message.reply_to_message.text
     if not query:
         await message.err("Give a query or reply to a message to google!")


### PR DESCRIPTION
Don't take reply to a message as a query when input message is there.